### PR TITLE
話者識別機能と設定永続化の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,11 @@ DropArea (DnD) → MainWindow → TranscriptionWorker (QThread)
                           mlx_whisper.transcribe()  →  mlx-community HuggingFace repo
                                   ↓
                           normalize_segments()  →  VADタイムラインを元タイムラインに再マッピング
+                                  ↓ (話者識別 ON のみ)
+                          diarization.diarize_pcm()  →  sherpa-onnx で話者区間検出
+                          diarization.assign_speakers()  →  各セグメントに話者ID付与
+                                  ↓
+                          segment_merger.merge_by_conversation()  →  話者境界でブロック分割
                                   ↓
                           file_naming.resolve_output_path()
                                   ↓
@@ -68,6 +73,14 @@ DropArea (DnD) → MainWindow → TranscriptionWorker (QThread)
 
 `file_naming.resolve_output_path()` は `meeting.wav` → `meeting.transcript.md` を生成し、衝突時は `meeting.transcript.1.md`, `meeting.transcript.2.md` と最小未使用番号で採番する。
 
+### 話者識別（Diarization）
+
+`services/diarization.py` は sherpa-onnx (ONNX 推論) で話者区間を検出する。HuggingFace アクセストークン不要・ライセンス受諾不要でオフライン動作。初回のみ k2-fsa の GitHub Releases から ONNX モデル (segmentation: pyannote-segmentation-3.0、embedding: 3D-Speaker eres2net) を取得し `~/Library/Application Support/mlx-audio-transcriptor/models/diarization/` にキャッシュする。`assign_speakers()` で Whisper セグメントと話者区間の時間重なりを計算し、最大 overlap の話者を割り当てる。`normalize_speaker_ids()` で初出順に `Speaker 1`, `Speaker 2`... と振り直す。話者識別 ON のとき `merge_by_conversation` は `respect_speaker=True` で動作し、話者境界でブロックを分割する。失敗時は `speaker_id=None` のまま処理続行。
+
+### 設定永続化
+
+`services/settings.py` は `~/Library/Application Support/mlx-audio-transcriptor/config.json` に言語・モデル・話者識別フラグを JSON で保存する。UI 上で値が変わるたびに即時保存し、起動時に `MainWindow` がロードして UI 状態を復元する。ファイル不在 / 破損時はデフォルト値 (`ja` / `medium` / `False`) にフォールバック。
+
 ## 出力フォーマット
 
 ```markdown
@@ -82,13 +95,27 @@ model: medium
 - [01:02:03.456 - 01:02:08.000] 1時間超えは HH:MM:SS.mmm 形式
 ```
 
+話者識別 ON のとき:
+
+```markdown
+---
+language: ja
+model: medium
+diarization: enabled
+---
+
+## Transcript
+
+- [00:00.000 - 00:03.200] **Speaker 1**: おはようございます。
+- [00:03.200 - 00:08.000] **Speaker 2**: こちらこそ、よろしくお願いします。
+```
+
 ## テスト対象モジュール
 
-ロジック層（`services/`）は GUI なしで単体テスト可能。`tests/` にはファイル命名と Markdown 生成のテストがある。`transcriber.py` と `vad.py` は `mlx-whisper` / `silero_vad` への依存があるためテスト外。
+ロジック層（`services/`）は GUI なしで単体テスト可能。`tests/` にはファイル命名・Markdown 生成・セグメントマージ・VAD 再マッピング・話者割り当て (`diarization.assign_speakers` / `normalize_speaker_ids`)・設定永続化のテストがある。`transcriber.py` と `vad.py` 本体、`diarization.diarize_pcm` / `ensure_models` は `mlx-whisper` / `silero_vad` / `sherpa_onnx` への依存があるためテスト外。
 
 ## 現時点の制限
 
 - キャンセル・一時停止不可（処理中ドロップは無視）
-- 話者分離・自動言語判定・動画ファイル非対応
-- 設定永続化なし（毎回 GUI から選択）
+- 自動言語判定・動画ファイル非対応
 - `.app` 化非対応

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -7,6 +7,7 @@ class Segment:
     start_sec: float
     end_sec: float
     text: str
+    speaker_id: int | None = None
 
 
 @dataclass
@@ -15,3 +16,4 @@ class TranscriptionResult:
     language: str
     model: str
     segments: list[Segment]
+    diarization_enabled: bool = False

--- a/app/services/diarization.py
+++ b/app/services/diarization.py
@@ -1,0 +1,223 @@
+"""話者識別 (speaker diarization) サービス。
+
+sherpa-onnx (ONNX 推論) をバックエンドに使い、HuggingFace アクセストークン不要・
+ライセンス受諾不要でオフライン動作する。モデルは k2-fsa の GitHub Releases から
+初回のみ自動ダウンロードしてユーザーディレクトリにキャッシュする。
+
+純粋関数 (`assign_speakers`, `normalize_speaker_ids`) は ML 依存なしで単体テスト可能。
+`diarize_pcm` / `ensure_models` は sherpa-onnx 依存のためテスト外。
+"""
+from __future__ import annotations
+
+import tarfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from app.models.types import Segment
+
+SpeakerInterval = Tuple[float, float, int]  # (start_sec, end_sec, speaker_id)
+
+_APP_DIR_NAME = "mlx-audio-transcriptor"
+
+_SEGMENTATION_ARCHIVE_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+    "speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+)
+_SEGMENTATION_ARCHIVE_NAME = "sherpa-onnx-pyannote-segmentation-3-0"
+_SEGMENTATION_MODEL_REL = "model.onnx"
+
+_EMBEDDING_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+    "speaker-recongition-models/3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
+)
+_EMBEDDING_FILE_NAME = "3dspeaker_speech_eres2net_base_sv_zh-cn_3dspeaker_16k.onnx"
+
+
+@dataclass
+class DiarizationModelPaths:
+    segmentation_model: Path
+    embedding_model: Path
+
+
+_diarizer_singleton = None  # type: ignore[var-annotated]
+
+
+def _get_cache_dir() -> Path:
+    return (
+        Path.home()
+        / "Library"
+        / "Application Support"
+        / _APP_DIR_NAME
+        / "models"
+        / "diarization"
+    )
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    urllib.request.urlretrieve(url, tmp)
+    tmp.replace(dest)
+
+
+def ensure_models() -> DiarizationModelPaths:
+    """初回のみ ONNX モデルを取得しキャッシュ。2 回目以降は即座にパスを返す。"""
+    cache = _get_cache_dir()
+    seg_dir = cache / _SEGMENTATION_ARCHIVE_NAME
+    seg_model = seg_dir / _SEGMENTATION_MODEL_REL
+    if not seg_model.exists():
+        archive = cache / f"{_SEGMENTATION_ARCHIVE_NAME}.tar.bz2"
+        _download(_SEGMENTATION_ARCHIVE_URL, archive)
+        with tarfile.open(archive, "r:bz2") as tf:
+            tf.extractall(cache)
+        archive.unlink(missing_ok=True)
+        if not seg_model.exists():
+            raise RuntimeError(
+                f"segmentation model not found at {seg_model} after extraction"
+            )
+
+    emb_model = cache / _EMBEDDING_FILE_NAME
+    if not emb_model.exists():
+        _download(_EMBEDDING_URL, emb_model)
+
+    return DiarizationModelPaths(
+        segmentation_model=seg_model,
+        embedding_model=emb_model,
+    )
+
+
+def _build_diarizer(cluster_threshold: float):
+    global _diarizer_singleton
+    if _diarizer_singleton is not None:
+        cached_threshold, instance = _diarizer_singleton
+        if cached_threshold == cluster_threshold:
+            return instance
+
+    import sherpa_onnx  # type: ignore[import]
+
+    paths = ensure_models()
+    config = sherpa_onnx.OfflineSpeakerDiarizationConfig(
+        segmentation=sherpa_onnx.OfflineSpeakerSegmentationModelConfig(
+            pyannote=sherpa_onnx.OfflineSpeakerSegmentationPyannoteModelConfig(
+                model=str(paths.segmentation_model),
+            ),
+        ),
+        embedding=sherpa_onnx.SpeakerEmbeddingExtractorConfig(
+            model=str(paths.embedding_model),
+        ),
+        clustering=sherpa_onnx.FastClusteringConfig(
+            num_clusters=-1,
+            threshold=cluster_threshold,
+        ),
+        min_duration_on=0.3,
+        min_duration_off=0.5,
+    )
+    if not config.validate():
+        raise RuntimeError("Invalid OfflineSpeakerDiarizationConfig")
+    instance = sherpa_onnx.OfflineSpeakerDiarization(config)
+    _diarizer_singleton = (cluster_threshold, instance)
+    return instance
+
+
+def diarize_pcm(
+    audio_pcm: np.ndarray,
+    sample_rate: int = 16_000,
+    cluster_threshold: float = 0.5,
+) -> list[SpeakerInterval]:
+    """VAD 連結タイムライン上の (start, end, speaker_id) リストを返す。
+
+    audio_pcm は float32 mono、サンプルレートは sherpa-onnx 側の期待値と
+    一致する必要がある (segmentation モデルは 16 kHz 固定)。
+    """
+    diarizer = _build_diarizer(cluster_threshold)
+    if sample_rate != diarizer.sample_rate:
+        raise ValueError(
+            f"audio sample_rate={sample_rate} does not match diarizer.sample_rate={diarizer.sample_rate}"
+        )
+    samples = np.ascontiguousarray(audio_pcm, dtype=np.float32)
+    result = diarizer.process(samples).sort_by_start_time()
+    return [(float(seg.start), float(seg.end), int(seg.speaker)) for seg in result]
+
+
+def assign_speakers(
+    segments: list[Segment],
+    speaker_intervals: list[SpeakerInterval],
+    kept_intervals: list[tuple[float, float]] | None,
+) -> list[Segment]:
+    """各 segment に最大 overlap の話者 ID を付与した新リストを返す。
+
+    speaker_intervals は VAD 連結タイムラインの座標。kept_intervals が
+    与えられた場合は元タイムラインへリマップしてから overlap を計算する。
+    overlap=0 の segment は speaker_id=None のまま残す。
+    """
+    if not speaker_intervals:
+        return [
+            Segment(
+                start_sec=s.start_sec,
+                end_sec=s.end_sec,
+                text=s.text,
+                speaker_id=s.speaker_id,
+            )
+            for s in segments
+        ]
+
+    if kept_intervals is not None:
+        from app.services.vad import remap_timestamp
+
+        mapped: list[SpeakerInterval] = [
+            (
+                remap_timestamp(s, kept_intervals),
+                remap_timestamp(e, kept_intervals),
+                sid,
+            )
+            for s, e, sid in speaker_intervals
+        ]
+    else:
+        mapped = list(speaker_intervals)
+
+    result: list[Segment] = []
+    for seg in segments:
+        best_id: int | None = None
+        best_overlap = 0.0
+        for s, e, sid in mapped:
+            overlap = min(seg.end_sec, e) - max(seg.start_sec, s)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_id = sid
+        result.append(
+            Segment(
+                start_sec=seg.start_sec,
+                end_sec=seg.end_sec,
+                text=seg.text,
+                speaker_id=best_id,
+            )
+        )
+    return result
+
+
+def normalize_speaker_ids(segments: list[Segment]) -> list[Segment]:
+    """初出順に 1, 2, 3... と振り直す。None はそのまま。"""
+    mapping: dict[int, int] = {}
+    next_id = 1
+    result: list[Segment] = []
+    for seg in segments:
+        if seg.speaker_id is None:
+            new_id: int | None = None
+        else:
+            if seg.speaker_id not in mapping:
+                mapping[seg.speaker_id] = next_id
+                next_id += 1
+            new_id = mapping[seg.speaker_id]
+        result.append(
+            Segment(
+                start_sec=seg.start_sec,
+                end_sec=seg.end_sec,
+                text=seg.text,
+                speaker_id=new_id,
+            )
+        )
+    return result

--- a/app/services/markdown_writer.py
+++ b/app/services/markdown_writer.py
@@ -18,15 +18,20 @@ def build_markdown(result: TranscriptionResult) -> str:
         "---",
         f"language: {result.language}",
         f"model: {result.model}",
+    ]
+    if result.diarization_enabled:
+        lines.append("diarization: enabled")
+    lines.extend([
         "---",
         "",
         "## Transcript",
         "",
-    ]
+    ])
     for seg in result.segments:
         start = format_time(seg.start_sec)
         end = format_time(seg.end_sec)
-        lines.append(f"- [{start} - {end}] {seg.text}")
+        prefix = f"**Speaker {seg.speaker_id}**: " if seg.speaker_id is not None else ""
+        lines.append(f"- [{start} - {end}] {prefix}{seg.text}")
     return "\n".join(lines) + "\n"
 
 

--- a/app/services/segment_merger.py
+++ b/app/services/segment_merger.py
@@ -9,6 +9,7 @@ def merge_by_conversation(
     silence_gap_sec: float = 0.8,
     max_block_sec: float = 30.0,
     language: str = "ja",
+    respect_speaker: bool = False,
 ) -> list[Segment]:
     if not segments:
         return []
@@ -18,20 +19,23 @@ def merge_by_conversation(
     block_start = segments[0].start_sec
     block_texts: list[str] = [segments[0].text.strip()]
     block_end = segments[0].end_sec
+    block_speaker = segments[0].speaker_id
 
     for prev, curr in zip(segments, segments[1:]):
         block_len = curr.end_sec - block_start
         gap = curr.start_sec - prev.end_sec
         ends_sentence = bool(prev.text.strip()) and prev.text.strip()[-1] in _SENTENCE_END
+        speaker_changed = respect_speaker and curr.speaker_id != block_speaker
 
-        if ends_sentence or gap >= silence_gap_sec or block_len > max_block_sec:
-            result.append(Segment(block_start, block_end, joiner.join(block_texts)))
+        if ends_sentence or gap >= silence_gap_sec or block_len > max_block_sec or speaker_changed:
+            result.append(Segment(block_start, block_end, joiner.join(block_texts), speaker_id=block_speaker))
             block_start = curr.start_sec
             block_texts = [curr.text.strip()]
+            block_speaker = curr.speaker_id
         else:
             block_texts.append(curr.text.strip())
 
         block_end = curr.end_sec
 
-    result.append(Segment(block_start, block_end, joiner.join(block_texts)))
+    result.append(Segment(block_start, block_end, joiner.join(block_texts), speaker_id=block_speaker))
     return result

--- a/app/services/settings.py
+++ b/app/services/settings.py
@@ -1,0 +1,51 @@
+"""ユーザー設定 (言語・モデル・話者識別 ON/OFF) の永続化。
+
+macOS の慣習に従い `~/Library/Application Support/mlx-audio-transcriptor/config.json`
+に保存する。値変更時に都度 save() を呼ぶ前提でクラッシュ耐性を確保。
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+
+_APP_DIR_NAME = "mlx-audio-transcriptor"
+_CONFIG_FILE_NAME = "config.json"
+
+
+@dataclass
+class AppSettings:
+    language: str = "ja"
+    model: str = "medium"
+    enable_diarization: bool = False
+
+
+def get_settings_path() -> Path:
+    return (
+        Path.home() / "Library" / "Application Support" / _APP_DIR_NAME / _CONFIG_FILE_NAME
+    )
+
+
+def load(path: Path | None = None) -> AppSettings:
+    target = path or get_settings_path()
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return AppSettings()
+    if not isinstance(raw, dict):
+        return AppSettings()
+    known = {f.name for f in fields(AppSettings)}
+    filtered = {k: v for k, v in raw.items() if k in known}
+    try:
+        return AppSettings(**filtered)
+    except TypeError:
+        return AppSettings()
+
+
+def save(settings: AppSettings, path: Path | None = None) -> None:
+    target = path or get_settings_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(asdict(settings), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )

--- a/app/services/transcriber.py
+++ b/app/services/transcriber.py
@@ -43,19 +43,24 @@ def transcribe(
     language: str,
     progress_callback: Callable[[int, int, float], None] | None = None,
     use_vad: bool = True,
+    enable_diarization: bool = False,
+    warning_callback: Callable[[str], None] | None = None,
 ) -> TranscriptionResult:
     repo = _MODEL_REPO_MAP.get(model, f"mlx-community/whisper-{model}-mlx")
 
     audio_input: str | object = str(source_path)
     kept_intervals = None
+    audio_pcm = None
 
     if use_vad:
         try:
             from app.services.vad import preprocess_with_vad
             audio_input, kept_intervals = preprocess_with_vad(source_path)
+            audio_pcm = audio_input
         except Exception:
             audio_input = str(source_path)
             kept_intervals = None
+            audio_pcm = None
 
     original_tqdm_cls = _tqdm_module.tqdm
     if progress_callback is not None:
@@ -76,13 +81,36 @@ def transcribe(
             _tqdm_module.tqdm = original_tqdm_cls
 
     segments = normalize_segments(result, kept_intervals)
+
+    diarization_ok = False
+    if enable_diarization:
+        try:
+            from app.services import diarization
+            from app.services.vad import _SAMPLE_RATE, _load_audio
+
+            pcm_for_diar = audio_pcm
+            kept_for_diar = kept_intervals
+            if pcm_for_diar is None:
+                pcm_for_diar = _load_audio(source_path)
+                kept_for_diar = None
+            intervals = diarization.diarize_pcm(pcm_for_diar, sample_rate=_SAMPLE_RATE)
+            segments = diarization.assign_speakers(segments, intervals, kept_for_diar)
+            segments = diarization.normalize_speaker_ids(segments)
+            diarization_ok = True
+        except Exception as e:
+            if warning_callback is not None:
+                warning_callback(f"話者識別に失敗したためスキップしました: {e}")
+
     from app.services.segment_merger import merge_by_conversation
-    segments = merge_by_conversation(segments, language=language)
+    segments = merge_by_conversation(
+        segments, language=language, respect_speaker=diarization_ok
+    )
     return TranscriptionResult(
         source_path=source_path,
         language=language,
         model=model,
         segments=segments,
+        diarization_enabled=diarization_ok,
     )
 
 

--- a/app/services/vad.py
+++ b/app/services/vad.py
@@ -2,12 +2,13 @@ import bisect
 from pathlib import Path
 
 import numpy as np
-import soundfile as sf
 
 _SAMPLE_RATE = 16_000
 
 
 def _load_audio(source_path: Path) -> np.ndarray:
+    import soundfile as sf
+
     data, sr = sf.read(str(source_path), dtype="float32", always_2d=True)
     mono = data.mean(axis=1)
     if sr != _SAMPLE_RATE:

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QHBoxLayout,
     QLabel,
@@ -15,7 +16,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.services import notifier
+from app.services import notifier, settings
 from app.ui.drop_area import SUPPORTED_EXTENSIONS, DropArea
 from app.workers.transcription_worker import TranscriptionWorker
 
@@ -33,7 +34,10 @@ class MainWindow(QMainWindow):
             self.setWindowIcon(QIcon(str(_APP_ICON_PATH)))
         self._worker: TranscriptionWorker | None = None
         self._processing = False
+        self._settings = settings.load()
         self._setup_ui()
+        self._apply_settings_to_ui()
+        self._connect_settings_persistence()
 
     def _setup_ui(self) -> None:
         central = QWidget()
@@ -48,21 +52,24 @@ class MainWindow(QMainWindow):
         self._drop_area.files_dropped.connect(self._on_files_dropped)
         root.addWidget(self._drop_area)
 
-        settings = QHBoxLayout()
-        settings.addWidget(QLabel("言語:"))
+        settings_row = QHBoxLayout()
+        settings_row.addWidget(QLabel("言語:"))
         self._lang_combo = QComboBox()
         for label, code in _LANGUAGES:
             self._lang_combo.addItem(label, code)
-        settings.addWidget(self._lang_combo)
-        settings.addSpacing(20)
-        settings.addWidget(QLabel("モデル:"))
+        settings_row.addWidget(self._lang_combo)
+        settings_row.addSpacing(20)
+        settings_row.addWidget(QLabel("モデル:"))
         self._model_combo = QComboBox()
         for m in _MODELS:
             self._model_combo.addItem(m)
         self._model_combo.setCurrentText(_DEFAULT_MODEL)
-        settings.addWidget(self._model_combo)
-        settings.addStretch()
-        root.addLayout(settings)
+        settings_row.addWidget(self._model_combo)
+        settings_row.addSpacing(20)
+        self._diarization_check = QCheckBox("話者識別")
+        settings_row.addWidget(self._diarization_check)
+        settings_row.addStretch()
+        root.addLayout(settings_row)
 
         self._status_label = QLabel("待機中")
         root.addWidget(self._status_label)
@@ -107,14 +114,21 @@ class MainWindow(QMainWindow):
         self._append_log("INFO", f"{len(valid)} files dropped")
         language: str = self._lang_combo.currentData()
         model: str = self._model_combo.currentText()
-        self._start_processing(valid, language, model)
+        enable_diarization: bool = self._diarization_check.isChecked()
+        self._start_processing(valid, language, model, enable_diarization)
 
-    def _start_processing(self, files: list[Path], language: str, model: str) -> None:
+    def _start_processing(
+        self,
+        files: list[Path],
+        language: str,
+        model: str,
+        enable_diarization: bool,
+    ) -> None:
         self._processing = True
         self._progress_bar.setValue(0)
         self._progress_bar.setVisible(True)
         self._status_label.setText(f"{len(files)}件中 1件目を処理中")
-        self._worker = TranscriptionWorker(files, language, model)
+        self._worker = TranscriptionWorker(files, language, model, enable_diarization)
         self._worker.log_message.connect(self._append_log)
         self._worker.status_update.connect(self._status_label.setText)
         self._worker.progress.connect(self._on_progress)
@@ -140,3 +154,26 @@ class MainWindow(QMainWindow):
 
     def _append_log(self, level: str, message: str) -> None:
         self._log_view.append(f"[{level}] {message}")
+
+    def _apply_settings_to_ui(self) -> None:
+        for i in range(self._lang_combo.count()):
+            if self._lang_combo.itemData(i) == self._settings.language:
+                self._lang_combo.setCurrentIndex(i)
+                break
+        if self._settings.model in _MODELS:
+            self._model_combo.setCurrentText(self._settings.model)
+        self._diarization_check.setChecked(self._settings.enable_diarization)
+
+    def _connect_settings_persistence(self) -> None:
+        self._lang_combo.currentIndexChanged.connect(self._persist_settings)
+        self._model_combo.currentTextChanged.connect(self._persist_settings)
+        self._diarization_check.toggled.connect(self._persist_settings)
+
+    def _persist_settings(self, *_args: object) -> None:
+        self._settings.language = self._lang_combo.currentData() or self._settings.language
+        self._settings.model = self._model_combo.currentText()
+        self._settings.enable_diarization = self._diarization_check.isChecked()
+        try:
+            settings.save(self._settings)
+        except OSError as e:
+            self._append_log("WARN", f"設定の保存に失敗: {e}")

--- a/app/workers/transcription_worker.py
+++ b/app/workers/transcription_worker.py
@@ -17,11 +17,18 @@ class TranscriptionWorker(QThread):
     progress = Signal(float)                   # overall_percent 0-100
     finished = Signal(bool, int, int)          # had_errors, success_count, failure_count
 
-    def __init__(self, files: list[Path], language: str, model: str) -> None:
+    def __init__(
+        self,
+        files: list[Path],
+        language: str,
+        model: str,
+        enable_diarization: bool = False,
+    ) -> None:
         super().__init__()
         self._files = files
         self._language = language
         self._model = model
+        self._enable_diarization = enable_diarization
 
     def run(self) -> None:
         total_files = len(self._files)
@@ -50,9 +57,17 @@ class TranscriptionWorker(QThread):
                     f"(経過 {_fmt_sec(elapsed)} / {eta_str})"
                 )
 
+            def on_warning(msg: str, _i=i) -> None:
+                self.log_message.emit("WARN", f"[{_i}/{total_files}] {msg}")
+
             try:
                 result = transcriber.transcribe(
-                    path, self._model, self._language, progress_callback=on_progress
+                    path,
+                    self._model,
+                    self._language,
+                    progress_callback=on_progress,
+                    enable_diarization=self._enable_diarization,
+                    warning_callback=on_warning,
                 )
                 output_path = file_naming.resolve_output_path(path)
                 markdown_writer.write(result, output_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PySide6
 mlx-whisper
 silero-vad
 soundfile
+sherpa-onnx>=1.10.30

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -1,0 +1,75 @@
+from app.models.types import Segment
+from app.services.diarization import assign_speakers, normalize_speaker_ids
+
+
+def seg(start, end, text="x", speaker_id=None):
+    return Segment(start_sec=start, end_sec=end, text=text, speaker_id=speaker_id)
+
+
+def test_assign_speakers_single_speaker_covers_all():
+    segments = [seg(0.0, 2.0), seg(2.0, 5.0)]
+    intervals = [(0.0, 10.0, 0)]
+    result = assign_speakers(segments, intervals, kept_intervals=None)
+    assert [s.speaker_id for s in result] == [0, 0]
+
+
+def test_assign_speakers_overlap_priority():
+    # segment [2, 5] overlaps A=[0,3] for 1s, B=[3,10] for 2s → B wins
+    segments = [seg(2.0, 5.0)]
+    intervals = [(0.0, 3.0, 0), (3.0, 10.0, 1)]
+    result = assign_speakers(segments, intervals, kept_intervals=None)
+    assert result[0].speaker_id == 1
+
+
+def test_assign_speakers_no_overlap_remains_none():
+    segments = [seg(10.0, 20.0)]
+    intervals = [(0.0, 5.0, 0)]
+    result = assign_speakers(segments, intervals, kept_intervals=None)
+    assert result[0].speaker_id is None
+
+
+def test_assign_speakers_empty_intervals_preserves_input():
+    segments = [seg(0.0, 1.0, speaker_id=99)]
+    result = assign_speakers(segments, [], kept_intervals=None)
+    assert result[0].speaker_id == 99
+
+
+def test_assign_speakers_with_kept_intervals_remap():
+    # 元音声 [2,5)+[8,12) → VAD タイムライン [0,3)+[3,7)
+    # speaker_interval (vad) [0,3) speaker=0, [3,7) speaker=1
+    # 元時間軸では [2,5) と [8,12)
+    # segment [3.0, 4.0] (元) は speaker=0 [2,5) と完全重複 → 0
+    # segment [9.0, 11.0] (元) は speaker=1 [8,12) と重複 → 1
+    kept = [(2.0, 5.0), (8.0, 12.0)]
+    intervals = [(0.0, 3.0, 0), (3.0, 7.0, 1)]
+    segments = [seg(3.0, 4.0), seg(9.0, 11.0)]
+    result = assign_speakers(segments, intervals, kept_intervals=kept)
+    assert [s.speaker_id for s in result] == [0, 1]
+
+
+def test_normalize_speaker_ids_first_seen_order():
+    segments = [
+        seg(0, 1, speaker_id=5),
+        seg(1, 2, speaker_id=2),
+        seg(2, 3, speaker_id=5),
+        seg(3, 4, speaker_id=2),
+        seg(4, 5, speaker_id=7),
+    ]
+    result = normalize_speaker_ids(segments)
+    assert [s.speaker_id for s in result] == [1, 2, 1, 2, 3]
+
+
+def test_normalize_speaker_ids_preserves_none():
+    segments = [
+        seg(0, 1, speaker_id=None),
+        seg(1, 2, speaker_id=3),
+        seg(2, 3, speaker_id=None),
+    ]
+    result = normalize_speaker_ids(segments)
+    assert [s.speaker_id for s in result] == [None, 1, None]
+
+
+def test_normalize_speaker_ids_zero_based_input():
+    segments = [seg(0, 1, speaker_id=0), seg(1, 2, speaker_id=1)]
+    result = normalize_speaker_ids(segments)
+    assert [s.speaker_id for s in result] == [1, 2]

--- a/tests/test_markdown_writer.py
+++ b/tests/test_markdown_writer.py
@@ -53,6 +53,43 @@ def test_build_markdown_empty_segments() -> None:
     assert "## Transcript" in md
 
 
+def test_build_markdown_with_speakers() -> None:
+    result = _make_result(
+        diarization_enabled=True,
+        segments=[
+            Segment(start_sec=0.0, end_sec=3.2, text="おはようございます。", speaker_id=1),
+            Segment(start_sec=3.2, end_sec=8.0, text="こちらこそ。", speaker_id=2),
+        ],
+    )
+    md = build_markdown(result)
+    assert "diarization: enabled" in md
+    assert "- [00:00.000 - 00:03.200] **Speaker 1**: おはようございます。" in md
+    assert "- [00:03.200 - 00:08.000] **Speaker 2**: こちらこそ。" in md
+
+
+def test_build_markdown_mixed_none_and_speaker() -> None:
+    result = _make_result(
+        diarization_enabled=True,
+        segments=[
+            Segment(start_sec=0.0, end_sec=1.0, text="不明", speaker_id=None),
+            Segment(start_sec=1.0, end_sec=2.0, text="既知", speaker_id=1),
+        ],
+    )
+    md = build_markdown(result)
+    assert "- [00:00.000 - 00:01.000] 不明" in md
+    assert "- [00:00.000 - 00:01.000] **Speaker" not in md
+    assert "- [00:01.000 - 00:02.000] **Speaker 1**: 既知" in md
+
+
+def test_build_markdown_no_diarization_omits_frontmatter_and_prefix() -> None:
+    result = _make_result(
+        segments=[Segment(start_sec=0.0, end_sec=1.0, text="テスト")],
+    )
+    md = build_markdown(result)
+    assert "diarization:" not in md
+    assert "**Speaker" not in md
+
+
 def test_write(tmp_path: Path) -> None:
     result = _make_result(
         source_path=tmp_path / "test.wav",

--- a/tests/test_segment_merger.py
+++ b/tests/test_segment_merger.py
@@ -3,8 +3,8 @@ from app.models.types import Segment
 from app.services.segment_merger import merge_by_conversation
 
 
-def seg(start, end, text):
-    return Segment(start_sec=start, end_sec=end, text=text)
+def seg(start, end, text, speaker_id=None):
+    return Segment(start_sec=start, end_sec=end, text=text, speaker_id=speaker_id)
 
 
 def test_empty():
@@ -84,3 +84,41 @@ def test_question_mark_splits():
     ]
     result = merge_by_conversation(segs, silence_gap_sec=0.8, language="ja")
     assert len(result) == 2
+
+
+def test_merge_respects_speaker_boundary():
+    segs = [
+        seg(0.0, 1.0, "おはよう", speaker_id=1),
+        seg(1.1, 2.0, "ございます", speaker_id=1),
+        seg(2.1, 3.0, "こちらこそ", speaker_id=2),
+    ]
+    result = merge_by_conversation(
+        segs, silence_gap_sec=0.8, language="ja", respect_speaker=True
+    )
+    assert len(result) == 2
+    assert result[0].speaker_id == 1
+    assert result[0].text == "おはようございます"
+    assert result[1].speaker_id == 2
+    assert result[1].text == "こちらこそ"
+
+
+def test_merge_speaker_disabled_unchanged():
+    segs = [
+        seg(0.0, 1.0, "おはよう", speaker_id=1),
+        seg(1.1, 2.0, "こちら", speaker_id=2),
+    ]
+    result = merge_by_conversation(segs, silence_gap_sec=0.8, language="ja")
+    assert len(result) == 1
+    assert result[0].text == "おはようこちら"
+
+
+def test_merge_propagates_speaker_id_when_no_split():
+    segs = [
+        seg(0.0, 1.0, "前半", speaker_id=3),
+        seg(1.1, 2.0, "後半", speaker_id=3),
+    ]
+    result = merge_by_conversation(
+        segs, silence_gap_sec=0.8, language="ja", respect_speaker=True
+    )
+    assert len(result) == 1
+    assert result[0].speaker_id == 3

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from app.services.settings import AppSettings, load, save
+
+
+def test_load_default_when_missing(tmp_path: Path) -> None:
+    settings = load(tmp_path / "missing.json")
+    assert settings == AppSettings()
+
+
+def test_load_default_when_corrupt(tmp_path: Path) -> None:
+    target = tmp_path / "broken.json"
+    target.write_text("{this is not json", encoding="utf-8")
+    assert load(target) == AppSettings()
+
+
+def test_load_default_when_top_level_not_dict(tmp_path: Path) -> None:
+    target = tmp_path / "list.json"
+    target.write_text("[1, 2, 3]", encoding="utf-8")
+    assert load(target) == AppSettings()
+
+
+def test_load_ignores_unknown_keys(tmp_path: Path) -> None:
+    target = tmp_path / "extra.json"
+    target.write_text(
+        '{"language": "en", "model": "tiny", "enable_diarization": true, "future_key": 42}',
+        encoding="utf-8",
+    )
+    settings = load(target)
+    assert settings.language == "en"
+    assert settings.model == "tiny"
+    assert settings.enable_diarization is True
+
+
+def test_save_and_reload_roundtrip(tmp_path: Path) -> None:
+    target = tmp_path / "config.json"
+    original = AppSettings(language="en", model="large-v3", enable_diarization=True)
+    save(original, target)
+    assert load(target) == original
+
+
+def test_save_creates_parent_dirs(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dirs" / "config.json"
+    save(AppSettings(), target)
+    assert target.exists()


### PR DESCRIPTION
## Summary

- **話者識別 (diarization)** を `sherpa-onnx` バックエンドで追加。HuggingFace アクセストークン・ライセンス受諾不要、Apple Silicon でオフライン動作。初回のみ k2-fsa の GitHub Releases から ONNX モデル (pyannote-segmentation-3.0 + 3D-Speaker eres2net) を自動 DL し `~/Library/Application Support/mlx-audio-transcriptor/models/diarization/` にキャッシュ。
- **UI トグル** (デフォルト OFF) を追加。話者数は自動検出 (UI で個数指定なし)。
- **設定永続化** を `~/Library/Application Support/mlx-audio-transcriptor/config.json` に追加。言語・モデル・話者識別フラグを記憶し、次回起動時に復元。

### 出力例 (話者識別 ON)
```markdown
---
language: ja
model: medium
diarization: enabled
---

## Transcript

- [00:00.000 - 00:03.200] **Speaker 1**: おはようございます。
- [00:03.200 - 00:08.000] **Speaker 2**: こちらこそ、よろしくお願いします。
```

### 主要な実装ポイント
- `Segment.speaker_id: int | None = None` を追加 (デフォルト None で既存呼び出しは無傷)
- `diarization.assign_speakers()` で各 Whisper セグメントに最大 overlap の話者を割り当て、`normalize_speaker_ids()` で初出順 1, 2, 3... にリナンバ
- `merge_by_conversation` に `respect_speaker` パラメータを追加し、話者識別 ON 時は話者境界でブロック分割
- diarization 失敗時は `speaker_id=None` のままフォールバック (VAD と同じパターン)、ワーカーが WARN ログを発行
- `vad.py` の `soundfile` を遅延 import 化 (純粋関数 `remap_timestamp` のテスト容易性向上)

## Test plan
- [x] 既存テスト 4 ファイルがリグレッションなし (file_naming, markdown_writer, segment_merger, vad)
- [x] 新規 `tests/test_diarization.py` (8 ケース) — assign_speakers の overlap 優先・kept_intervals リマップ・normalize_speaker_ids
- [x] 新規 `tests/test_settings.py` (6 ケース) — 不在/破損/上書き/親dir自動作成
- [x] `tests/test_markdown_writer.py` 追加ケース — speaker あり/なし混在、フロントマター変化
- [x] `tests/test_segment_merger.py` 追加ケース — respect_speaker の境界分割と既存挙動維持
- [x] 全 45 テスト pass
- [ ] **手動確認 (Apple Silicon Mac で実施推奨)**:
  - [ ] OFF のまま音声ドロップ → 既存と同一の Markdown
  - [ ] ON で音声ドロップ → 初回 ONNX DL 後、`**Speaker N**:` プレフィックス付き出力
  - [ ] アプリ再起動 → 言語・モデル・チェック状態が前回値で復元
  - [ ] sherpa-onnx 未インストール時は WARN ログのみで処理継続

https://claude.ai/code/session_01Lgqeh8gtEoTfZ1FUcX8caQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgqeh8gtEoTfZ1FUcX8caQ)_