### PR TITLE
feat: CLI scan で処理中に追加された音声ファイルも再スキャンで拾う

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,9 @@ launchd WatchPaths=~/Downloads
     ↓
 app.cli scan
     ↓  fcntl.flock で重複起動を抑止
-_process_pending()  ─  拡張子・既処理判定（*.transcript.md 有無）・stability wait
+_process_pending()  ─  _scan_once() を「処理件数 0」になるまで再実行（処理中に追加されたファイルも拾う、最大 _RESCAN_MAX_PASSES 回）
+    ↓
+_scan_once()  ─  拡張子・既処理判定（*.transcript.md 有無）・stability wait
     ↓
 _transcribe_one()
     ├─ notifier.notify("文字起こし開始", …)

--- a/app/cli.py
+++ b/app/cli.py
@@ -27,6 +27,7 @@ _LOG_DIR = Path.home() / "Library" / "Logs" / "mlx-audio-transcriptor"
 _CLI_LOG_PATH = _LOG_DIR / "cli.log"
 _STABILITY_TIMEOUT_SEC = 120.0
 _STABILITY_POLL_SEC = 1.0
+_RESCAN_MAX_PASSES = 100
 
 
 def _already_transcribed(source: Path) -> bool:
@@ -95,11 +96,7 @@ def _transcribe_one(path: Path, cfg: AppConfig) -> None:
             logger.warning("trash failed for %s: %s", path, e)
 
 
-def _process_pending(cfg: AppConfig) -> int:
-    if not cfg.watch_dir.is_dir():
-        logger.warning("watch_dir does not exist: %s", cfg.watch_dir)
-        return 0
-
+def _scan_once(cfg: AppConfig) -> tuple[int, int]:
     processed = 0
     errors = 0
     for path in sorted(cfg.watch_dir.iterdir()):
@@ -117,9 +114,33 @@ def _process_pending(cfg: AppConfig) -> int:
         except Exception as e:
             errors += 1
             logger.error("failed to transcribe %s: %s", path, e, exc_info=True)
+    return processed, errors
 
-    logger.info("scan done: processed=%d errors=%d", processed, errors)
-    return 1 if errors else 0
+
+def _process_pending(cfg: AppConfig) -> int:
+    if not cfg.watch_dir.is_dir():
+        logger.warning("watch_dir does not exist: %s", cfg.watch_dir)
+        return 0
+
+    total_processed = 0
+    total_errors = 0
+    for pass_index in range(1, _RESCAN_MAX_PASSES + 1):
+        processed, errors = _scan_once(cfg)
+        total_processed += processed
+        total_errors += errors
+        if processed == 0:
+            break
+        logger.info(
+            "rescan pass %d: processed=%d errors=%d; re-checking watch_dir for new files",
+            pass_index,
+            processed,
+            errors,
+        )
+    else:
+        logger.warning("rescan pass cap reached (%d); stopping", _RESCAN_MAX_PASSES)
+
+    logger.info("scan done: processed=%d errors=%d", total_processed, total_errors)
+    return 1 if total_errors else 0
 
 
 def cmd_scan(cfg: AppConfig | None = None, lock_path: Path | None = None) -> int:

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -184,6 +184,39 @@ def test_minutes_invoked_when_enabled(tmp_path: Path, patched, monkeypatch) -> N
     assert kwargs["notify"] is not None
 
 
+def test_rescans_watch_dir_after_processing(tmp_path: Path, monkeypatch) -> None:
+    trash_mock = MagicMock()
+    monkeypatch.setattr("app.cli.send2trash.send2trash", trash_mock)
+
+    later_audio = tmp_path / "later.wav"
+
+    def fake_transcribe(path: Path, model: str, language: str, **_kwargs) -> TranscriptionResult:
+        if path.name == "first.wav" and not later_audio.exists():
+            later_audio.write_bytes(b"fake")
+        return TranscriptionResult(
+            source_path=path,
+            language=language,
+            model=model,
+            segments=[],
+        )
+
+    transcribe_mock = MagicMock(side_effect=fake_transcribe)
+    monkeypatch.setattr("app.cli.transcriber.transcribe", transcribe_mock)
+
+    (tmp_path / "first.wav").write_bytes(b"fake")
+
+    rc = cli.cmd_scan(
+        cfg=_cfg(tmp_path, trash_source_after_success=False),
+        lock_path=tmp_path / "scan.lock",
+    )
+
+    assert rc == 0
+    transcribed = sorted(call.args[0].name for call in transcribe_mock.call_args_list)
+    assert transcribed == ["first.wav", "later.wav"]
+    assert (tmp_path / "first.transcript.md").exists()
+    assert (tmp_path / "later.transcript.md").exists()
+
+
 def test_minutes_none_return_does_not_block_trash(tmp_path: Path, patched, monkeypatch) -> None:
     _, trash_mock = patched
     monkeypatch.setattr("app.cli.minutes.run_for", MagicMock(return_value=None))


### PR DESCRIPTION
## Summary

- CLI 実行中に Downloads へ新規音声ファイルが投下された場合、これまでは当初スキャンで拾われず、launchd の次回イベントを待つ必要があった
- `_process_pending` を「`_scan_once` が処理件数 0 を返すまで繰り返す」do-while 形に変更し、処理中に追加されたファイルも同一プロセス内で順次処理する
- 暴走防止に `_RESCAN_MAX_PASSES = 100` のパスキャップを設定（上限到達時は WARN ログ）
- `flock` による重複起動抑止はそのまま維持されるので、別 launchd 起動と衝突しない

## Implementation notes

- `_scan_once(cfg)` を切り出し（拡張子・既処理判定・stability wait・1 ファイル文字起こしを 1 パス分）
- 各パス終了後にもう一度 `cfg.watch_dir.iterdir()` を回すため、処理中に到着したファイルが次パスで拾われる
- 既に書き出した `*.transcript.md` の存在チェックがあるので、前パスで処理済みのファイルを再処理することは無い

## Test plan

- [x] 既存の `tests/test_cli_scan.py` がパスする（既存の 1 件失敗は main からの先行回帰で本 PR とは無関係）
- [x] 新規 `test_rescans_watch_dir_after_processing`: 最初のファイル処理中に 2 つ目のファイルを書き込むスタブを仕込み、両方が文字起こしされること、両方の `.transcript.md` が生成されることを確認
- [ ] 手動: macOS 上で CLI 実行中に Downloads へ追加投入 → 同一プロセスで連続処理されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUBUwCfNpXCJGV1Nm8PBiX)_